### PR TITLE
Use BTreeSet for sorted results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use cargo_metadata::MetadataCommand;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::process::Command;
 
 pub fn run() {
@@ -20,13 +20,13 @@ pub fn run() {
     let metadata = cmd.exec().unwrap();
 
     let root_package = metadata.root_package().unwrap();
-    let mut root_deps = HashSet::new();
+    let mut root_deps = BTreeSet::new();
     for dep in &root_package.dependencies {
         // println!("        dep {}: {:?}", dep.name, dep);
         root_deps.insert(dep.name.to_owned());
     }
 
-    let mut all_other_deps = HashSet::new();
+    let mut all_other_deps = BTreeSet::new();
     for pkg in &metadata.packages {
         println!(
             "name: {}, version: {}, edition: {}",
@@ -54,7 +54,7 @@ pub fn run() {
     println!("root_deps: {:?}", root_deps);
     println!("dup_crates: {:?}", dup_crates);
 
-    let mut maybe_unused = HashSet::new();
+    let mut maybe_unused = BTreeSet::new();
     for c in dup_crates {
         if let Ok(true) = find_usage(&c) {
             continue;


### PR DESCRIPTION
Much easier to look through the results when they are sorted. Perf implications should be unnoticeable practically speaking.