### PR TITLE
Fail hard if rg is not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
-fn main() {
-    cargo_inner::run();
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    cargo_inner::run()
 }


### PR DESCRIPTION
Previously, it would just mark all the crates as unused,
which is a bit of a confusing result. This fails fast with
a nice error message, explaining that rg is missing.